### PR TITLE
Proposal to improve id generation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,11 @@ services:
       - 13306:3306
     environment:
       MYSQL_ROOT_PASSWORD: root
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    environment:
+      - PMA_HOST=db
+    restart: always
+    ports:
+      - 8080:80

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -9,6 +9,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class AppFixtures extends Fixture
 {
+    public const ADMIN_USER_REFERENCE = 'admin-user';
     private $passwordEncoder;
 
     public function __construct(UserPasswordEncoderInterface $passwordEncoder)
@@ -30,5 +31,8 @@ class AppFixtures extends Fixture
 
         $manager->persist($adminUser);
         $manager->flush();
+
+        // other fixtures can get this object user AppFixtures::ADMIN_USER_REFERENCE
+        $this->addReference(self::ADMIN_USER_REFERENCE, $adminUser);
     }
 }

--- a/src/DataFixtures/LogFixtures.php
+++ b/src/DataFixtures/LogFixtures.php
@@ -1,0 +1,53 @@
+<?php
+
+
+namespace App\DataFixtures;
+
+
+use App\Entity\Device;
+use App\Entity\Log;
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class LogFixtures extends Fixture
+{
+    private $MAX_DEVICE = 10;
+    private $MAX_LOG_PER_DEVICE = 100;
+    private $SEC_BETWEEN_EACH_LOG = 60;
+
+    public function load(ObjectManager $manager)
+    {
+        /** @var User $user */
+        $user = $this->getReference(AppFixtures::ADMIN_USER_REFERENCE);
+        $user = $manager->getRepository(User::class)->findOneByApiToken($user->getApiToken());
+
+        $deviceCounter = 0;
+        while ($deviceCounter <= $this->MAX_DEVICE) {
+            $device = new Device();
+            $device->setUser($user);
+            $device->setPlace('Device ' . $deviceCounter);
+            $manager->persist($device);
+            $manager->flush();
+
+            $dt = new \DateTime();
+            $logCounter = 0;
+            while ($logCounter <= $this->MAX_LOG_PER_DEVICE) {
+                $log = new Log();
+                $log->setDevice($device);
+                $log->setDate($dt);
+                $log->setType('t');
+                $log->setValue(random_int(-12, 32));
+
+                $dt->add(new \DateInterval('PT' . $this->SEC_BETWEEN_EACH_LOG . 'S'));
+                $logCounter++;
+                $manager->persist($log);
+                $manager->flush();
+            }
+
+            $deviceCounter++;
+        }
+        $manager->flush();
+    }
+
+}

--- a/src/Doctrine/RandomIdGenerator.php
+++ b/src/Doctrine/RandomIdGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Doctrine;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+
+class RandomIdGenerator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity)
+    {
+        $entity_name = $em->getClassMetadata(get_class($entity))->getName();
+
+        while (true) {
+            $id = $this->generateRandomString(48);
+            $item = $em->find($entity_name, $id);
+
+            if (!$item) {
+                return $id;
+            }
+        }
+    }
+
+    /**
+     * Returns a random string of the given length
+     *
+     * @param int $length Length of the string (default: 10 characters)
+     * @return string
+     */
+    private function generateRandomString($length = 10)
+    {
+        $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $charactersLength = strlen($characters);
+        $randomString = '';
+        for ($i = 0; $i < $length; $i++) {
+            $randomString .= $characters[rand(0, $charactersLength - 1)];
+        }
+        return $randomString;
+    }
+}

--- a/src/Entity/Device.php
+++ b/src/Entity/Device.php
@@ -13,8 +13,9 @@ class Device
 {
     /**
      * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="App\Doctrine\RandomIdGenerator")
+     * @ORM\Column(type="string", length=48)
      */
     private $id;
 

--- a/src/Entity/Log.php
+++ b/src/Entity/Log.php
@@ -13,8 +13,9 @@ class Log
 {
     /**
      * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="App\Doctrine\RandomIdGenerator")
+     * @ORM\Column(type="string", length=48)
      */
     private $id;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,8 +14,9 @@ class User implements UserInterface
 {
     /**
      * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="App\Doctrine\RandomIdGenerator")
+     * @ORM\Column(type="string", length=48)
      */
     private $id;
 


### PR DESCRIPTION
I wrote a class implementing AbstractIdGenerator that generates a random string of 48 characters length, to be used on all entities as primary key. 
using those resources: 

- [Random
 string generator](https://stackoverflow.com/questions/4356289/php-random-string-generator#4356295)
- [Implementation of id generator](https://stackoverflow.com/questions/15039665/generate-unique-id-doctrine-symfony2)

Then, I updated and added log fixture to poc. It loads 10 devices with 100 logs each.\
Based on the length given to the **type** field of the **log** entity, i chose to put the char _t_ meaning _temperature_.

Suggestions are welcomed ! :)